### PR TITLE
Feature: allow transcoding to be canceled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-# VS 2013 code browsing database #
+# Visual Studio generated files #
 *.sdf
 *.opensdf
+ipch/
+[Dd]ebug*/
+[Rr]elease*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Visual Studio generated files #
 *.sdf
 *.opensdf
+*.suo
 ipch/
 [Dd]ebug*/
 [Rr]elease*/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 ipch/
 [Dd]ebug*/
 [Rr]elease*/
+
+# Project specific files#
+TestInput*/
+TestOutput*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# VS 2013 code browsing database #
+*.sdf
+*.opensdf

--- a/Test_M4ATranscode/main.cpp
+++ b/Test_M4ATranscode/main.cpp
@@ -2,12 +2,37 @@
 #include <atlstr.h>
 
 typedef void(*WaveToM4A_FUNC)(WCHAR*, WCHAR*);
+//typedef void(*CancelWaveToM4A_FUNC)(void);
+
+DWORD WINAPI TranscoderThread(LPVOID lpParam);
 
 int main()
 {
    HMODULE hMod;
    CString strDLLPath = _T("WavToM4A.dll");
    hMod = LoadLibrary(strDLLPath);
+   //CancelWaveToM4A_FUNC cancelfunc = (CancelWaveToM4A_FUNC)GetProcAddress(hMod, "CancelWaveToM4A");
+
+   // spawn transcoder in a separate thread
+   DWORD transcoderThreadId;
+   HANDLE hTranscoderThread = CreateThread(
+      NULL,
+      0,
+      TranscoderThread,
+      hMod,
+      0,
+      &transcoderThreadId);
+
+   // wait for transcoding to finish
+   WaitForSingleObject(hTranscoderThread, INFINITE);
+   CloseHandle(hTranscoderThread);
+
+   return 0;
+}
+
+DWORD WINAPI TranscoderThread(LPVOID lpParam)
+{
+   HMODULE hMod = (HMODULE)lpParam;
 
    WCHAR strInput[] = L"HugeWAV.wav";
    WCHAR strOutput[] = L"Output.m4a";
@@ -17,4 +42,6 @@ int main()
    {
       convertfunc((WCHAR*)&strInput, (WCHAR*)&strOutput);
    }
+
+   return 0;
 }

--- a/Test_M4ATranscode/main.cpp
+++ b/Test_M4ATranscode/main.cpp
@@ -1,8 +1,11 @@
 #include <Windows.h>
 #include <atlstr.h>
 
+// uncomment to test features
+//#define TEST_CANCEL_TRANSCODE
+
 typedef void(*WaveToM4A_FUNC)(WCHAR*, WCHAR*);
-//typedef void(*CancelWaveToM4A_FUNC)(void);
+typedef void(*CancelWaveToM4A_FUNC)(void);
 
 DWORD WINAPI TranscoderThread(LPVOID lpParam);
 
@@ -11,7 +14,7 @@ int main()
    HMODULE hMod;
    CString strDLLPath = _T("WavToM4A.dll");
    hMod = LoadLibrary(strDLLPath);
-   //CancelWaveToM4A_FUNC cancelfunc = (CancelWaveToM4A_FUNC)GetProcAddress(hMod, "CancelWaveToM4A");
+   CancelWaveToM4A_FUNC cancelfunc = (CancelWaveToM4A_FUNC)GetProcAddress(hMod, "CancelWaveToM4A");
 
    // spawn transcoder in a separate thread
    DWORD transcoderThreadId;
@@ -22,6 +25,11 @@ int main()
       hMod,
       0,
       &transcoderThreadId);
+
+#ifdef TEST_CANCEL_TRANSCODE
+   Sleep(2000);
+   cancelfunc();
+#endif
 
    // wait for transcoding to finish
    WaitForSingleObject(hTranscoderThread, INFINITE);

--- a/Test_M4ATranscode/main.cpp
+++ b/Test_M4ATranscode/main.cpp
@@ -42,8 +42,8 @@ DWORD WINAPI TranscoderThread(LPVOID lpParam)
 {
    HMODULE hMod = (HMODULE)lpParam;
 
-   WCHAR strInput[] = L"HugeWAV.wav";
-   WCHAR strOutput[] = L"Output.m4a";
+   WCHAR strInput[] = L"TestInput/HugeWAV.wav";
+   WCHAR strOutput[] = L"TestOutput/Output.m4a";
 
    WaveToM4A_FUNC convertfunc = (WaveToM4A_FUNC)GetProcAddress(hMod, "WaveToM4A");
    if (convertfunc != NULL)

--- a/WavToM4A/M4ATranscoder.cpp
+++ b/WavToM4A/M4ATranscoder.cpp
@@ -5,6 +5,7 @@
 
 M4ATranscoder::M4ATranscoder()
 {
+   m_Canceling = false;
 }
 
 M4ATranscoder::~M4ATranscoder()
@@ -66,9 +67,15 @@ bool M4ATranscoder::Transcode(WCHAR* pstrInput, WCHAR* pstrOutput)
          //PROPVARIANT propOffset;
          //pEvent->GetItem(MF_EVENT_START_PRESENTATION_TIME_AT_OUTPUT, &propOffset);
       //}
+      // TODO: if m_Canceling is true, stop encoding, delete the output file, and exit
       Sleep(100);
    }
    return true;
+}
+
+void M4ATranscoder::CancelTranscode()
+{
+   m_Canceling = true;
 }
 
 void TraceWavFormatEx(const WAVEFORMATEX * const wfx)

--- a/WavToM4A/M4ATranscoder.cpp
+++ b/WavToM4A/M4ATranscoder.cpp
@@ -92,6 +92,7 @@ bool M4ATranscoder::Transcode(WCHAR* pstrInput, WCHAR* pstrOutput)
 
 void M4ATranscoder::CancelTranscode()
 {
+   std::cout << "cancel" << std::endl;
    m_Canceling = true;
 }
 

--- a/WavToM4A/M4ATranscoder.cpp
+++ b/WavToM4A/M4ATranscoder.cpp
@@ -75,9 +75,10 @@ bool M4ATranscoder::Transcode(WCHAR* pstrInput, WCHAR* pstrOutput)
       Sleep(100);
    }
 
+   // if we just canceled, remove the leftover file
    if (m_Canceling)
    {
-      // if we just canceled, remove the leftover file
+      m_Canceling = false;
       BOOL deleteResult = DeleteFile(pstrOutput);
       if (deleteResult == 0)
       {

--- a/WavToM4A/M4ATranscoder.h
+++ b/WavToM4A/M4ATranscoder.h
@@ -18,6 +18,7 @@ public:
    ~M4ATranscoder();
 
    bool Transcode(WCHAR* pstrInput, WCHAR* pstrOutput);
+   void CancelTranscode();
 
 protected:
    HRESULT ConfigureOutput(WCHAR* pstrOutput, CComPtr<IMFStreamDescriptor> stream_desc,
@@ -26,4 +27,5 @@ protected:
 protected:
    CComPtr<IMFMediaSession> m_MediaSession;
    CComQIPtr<IMFMediaSource> m_Source;
+   bool m_Canceling;
 };

--- a/WavToM4A/WavToM4A.cpp
+++ b/WavToM4A/WavToM4A.cpp
@@ -4,6 +4,8 @@
 #include "stdafx.h"
 #include "M4ATranscoder.h"
 
+M4ATranscoder* _Encoder = NULL;
+
 extern "C" __declspec(dllexport) void WaveToM4A(WCHAR* pstrInput, WCHAR* pstrOutput)
 {
    HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
@@ -17,12 +19,19 @@ extern "C" __declspec(dllexport) void WaveToM4A(WCHAR* pstrInput, WCHAR* pstrOut
    }
 
    {
-      M4ATranscoder encoder;
-      encoder.Transcode(pstrInput, pstrOutput);
+      _Encoder = new M4ATranscoder();
+      _Encoder->Transcode(pstrInput, pstrOutput);
    }
+
+   delete _Encoder;
+   _Encoder = NULL;
 
    MFShutdown();
    CoUninitialize();
 }
 
-
+extern "C" __declspec(dllexport) void CancelWaveToM4A()
+{
+   if (_Encoder)
+      _Encoder->CancelTranscode();
+}


### PR DESCRIPTION
According to MSDN, to cancel a Media Foundation session, you need to call `Close()` first, then wait for the `MESessionClosed` event before shutting everything down. This involved updating the test project to use a thread for transcoding.

Also added a gitignore file for all the Visual Studio generated files and audio test files, should make it easier to do adds and commits.
