### PR TITLE
Move the CoInitialize stuff out of the DLL; because it was keeping CS fr...

### DIFF
--- a/Test_M4ATrandcoderMFC/CWaveToM4A.cpp
+++ b/Test_M4ATrandcoderMFC/CWaveToM4A.cpp
@@ -78,8 +78,15 @@ bool CWaveToM4A::GetCanceled()
 DWORD WINAPI CWaveToM4A::TranscoderThread(LPVOID lpParam)
 {
    CWaveToM4A* pThiz = (CWaveToM4A*)lpParam;
+
+   HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
    DWORD dwRet = pThiz->TranscoderWorker() ? 1 : 0;
+
+   CoUninitialize();
+
    pThiz->m_hTranscoderThread = 0;
+
    return dwRet;
 }
 

--- a/WavToM4A/WavToM4A.cpp
+++ b/WavToM4A/WavToM4A.cpp
@@ -22,19 +22,10 @@ WAVETOM4A_EXTERN void WaveToM4A(WaveToM4AHandle pHandle, WCHAR* pstrInput, WCHAR
 {
    HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
 
-   // Initialize the COM library.
-   HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+   HRESULT hr = MFStartup(MF_VERSION);
 
-   if (SUCCEEDED(hr))
-   {
-      hr = MFStartup(MF_VERSION);
-   }
-
-   {
-      M4ATranscoder* pWav2M4A = (M4ATranscoder*)pHandle;
-      pWav2M4A->Transcode(pstrInput, pstrOutput, pProgress);
-   }
+   M4ATranscoder* pWav2M4A = (M4ATranscoder*)pHandle;
+   pWav2M4A->Transcode(pstrInput, pstrOutput, pProgress);
 
    MFShutdown();
-   CoUninitialize();
 }


### PR DESCRIPTION
...om producing twice without restarting.
